### PR TITLE
Profile-less migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ The following two variations of the `wpsdb migrate` command are possible by supp
 **action** can be set to either `pull` or `push` depending on the direction of the DB sync
 
 **create-backup** is a bit field that indicates whether the DB should be backed up prior to a transfer. This defaults to 1.
+
+#### Target a profile and fallback to a connection string 
+`wp wpsdb migrate --profile=1 --connection-info=https://example.com\n6AvE1jnBHIZtITuNCXj2eZArNM8uqNXC --action=pull --create-backup=1`
+
+In this example we can attempt to target a profile that doesn't yet exist before the migration and instead fallback to the manual profile arguments provided. Once the migration is complete if we re-run this command, then the profile will have been migrated over and this will be used. This is useful from an automation point of view.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # WP Sync DB CLI
 An addon for [WP Sync DB](https://github.com/slang800/wp-sync-db) that allows you to execute migrations using a function call or via WP-CLI
+
+## Example usage
+The following two variations of the `wpsdb migrate` command are possible by supplying either a profile id or connection info string. 
+
+#### Target a user created profile already stored in the system/database
+`wp wpsdb migrate --profile=1`
+
+**profile** represents the profile number as seen in the Migrate tab's "saved migration profiles" list in WP.
+
+#### Manually target a connection string (no profile)
+`wp wpsdb migrate --connection-info=https://example.com\n6AvE1jnBHIZtITuNCXj2eZArNM8uqNXC --action=pull --create-backup=1`
+
+**connection-info** is the string found on the target site's Settings tab. The line break is replaced with the `\n` equivalent character in order to pass the whole string on a single line.
+
+**action** can be set to either `pull` or `push` depending on the direction of the DB sync
+
+**create-backup** is a bit field that indicates whether the DB should be backed up prior to a transfer. This defaults to 1.

--- a/class/command.php
+++ b/class/command.php
@@ -39,6 +39,7 @@ class WPSDBCLI extends WP_CLI_Command
 	 *
 	 * 	wp wpsdb migrate --profile=1
 	 * 	wp wpsdb migrate --connection-info=https://example.com\n6AvE1jnBHIZtITuNCXj2eZArNM8uqNXC --action=pull --create-backup=1
+	 *  wp wpsdb migrate --profile=1 --connection-info=https://example.com\n6AvE1jnBHIZtITuNCXj2eZArNM8uqNXC --action=pull --create-backup=1
 	 *
 	 * @synopsis [--profile=<int>] [--connection-info=<string>] [--action=<string>] [--create-backup=<bit>]
 	 *

--- a/class/command.php
+++ b/class/command.php
@@ -3,53 +3,103 @@
 /**
  * Migrate your DB using WP Sync DB.
  */
-class WPSDBCLI extends WP_CLI_Command {
+class WPSDBCLI extends WP_CLI_Command
+{
 
 	/**
-	 * Run a migration.
+	 * Run a migration. Either profile id or connection-info + action are required.
 	 *
 	 * ## OPTIONS
 	 *
-	 * <profile>
+	 * [--profile=<int>] 
 	 * : ID of the profile to use for the migration.
+	 * 
+	 * [--connection-info=<string>]
+	 * : Manual connection info for when a profile by the ID is not found. The above ID will be used to save a copy
+	 * 
+	 * [--action=<string>]
+	 * : The type of action to perform against the target connection
+	 * ---
+	 * default: pull
+	 * options:
+	 *   - pull
+	 *   - push
+	 * ---
 	 *
+	 * [--create-backup=<bit>]
+	 * : Whether to take a backup before running the action.
+	 * ---
+	 * default: 0
+	 * options:
+	 *   - 0
+	 *   - 1
+	 * ---
+	 * 
 	 * ## EXAMPLES
 	 *
-	 * 	wp wpsdb migrate 1
+	 * 	wp wpsdb migrate --profile=1
+	 * 	wp wpsdb migrate --connection-info=https://example.com\n6AvE1jnBHIZtITuNCXj2eZArNM8uqNXC --action=pull --create-backup=1
 	 *
-	 * @synopsis <profile>
+	 * @synopsis [--profile=<int>] [--connection-info=<string>] [--action=<string>] [--create-backup=<bit>]
 	 *
 	 * @since 1.0
 	 */
-	public function migrate( $args, $assoc_args ) {
-		$profile = $args[0];
+	public function migrate($args, $assoc_args)
+	{
+		$profile = null;
 		$manual_profile = [];
 
 		// Target manually (maybe no database available yet)
+
+		if ($assoc_args['profile']) {
+			$profile = $assoc_args['profile'];
+		}
 		if ($assoc_args['connection-info'] && $assoc_args['action']) {
+			// Preprocess some variables
+			$connection_info = stripcslashes($assoc_args['connection-info']);
+			$connection_info_segments = explode("\n", $connection_info);
+			$friendly_name = preg_replace("(^https?://)", "", $connection_info_segments[0]);
+
+			// Create a default profile, that will save afterwards
 			$manual_profile = array(
-				'connection_info' 		=> $assoc_args['connection-info'],
+				'connection_info' 		=> $connection_info,
 				'action' 				=> $assoc_args['action'],
-				'create_backup' 		=> $assoc_args['create_backup'],
-				'backup_option' 		=> null,
-				'prefixed_tables' 		=> null,
+				'create_backup' 		=> $assoc_args['create-backup'],
+				'backup_option' 		=> "backup_only_with_prefix",
 				'select_backup' 		=> null,
-				'table_migrate_option' 	=> null,
 				'select_tables' 		=> null,
+				'table_migrate_option' 	=> "migrate_only_with_prefix",
+				'exclude_transients'    => 1,
+				'media_files'           => 1,
+				'remove_local_media'    => 1,
+				'save_migration_profile_option' => 0,
+				'create_new_profile'    => $friendly_name,
+				'name'                  => $friendly_name,
+				'save_computer'         => 0,
+				'gzip_file'             => 1,
+				'replace_guids'         => 1,
+				'exclude_spam'          => 0,
+				'keep_active_plugins'   => 1,
+				'exclude_post_types'    => 0
 			);
 		}
 
-		$result = wpsdb_migrate( $profile, $manual_profile );
-
-		if ( true === $result ) {
-			WP_CLI::success( __( 'Migration successful.', 'wp-sync-db-cli' ) );
+		if ($profile == null && empty($manual_profile)) {
+			WP_CLI::warning(__('Either profile id or connection-info + action are required.', 'wp-sync-db-cli'));
+			WP_CLI::log('Usage: wpsdb migrate [--profile=<int>] [--connection-info=<string>] [--action=<string>] [--create-backup=<bit>]');
 			return;
 		}
 
-		WP_CLI::warning( $result->get_error_message() );
+		$result = wpsdb_migrate($profile, $manual_profile);
+
+		if (true === $result) {
+			WP_CLI::success(__('Migration successful.', 'wp-sync-db-cli'));
+			return;
+		}
+
+		WP_CLI::warning($result->get_error_message());
 		return;
 	}
-
 }
 
-WP_CLI::add_command( 'wpsdb', 'WPSDBCLI' );
+WP_CLI::add_command('wpsdb', 'WPSDBCLI');

--- a/class/command.php
+++ b/class/command.php
@@ -29,7 +29,7 @@ class WPSDBCLI extends WP_CLI_Command
 	 * [--create-backup=<bit>]
 	 * : Whether to take a backup before running the action.
 	 * ---
-	 * default: 0
+	 * default: 1
 	 * options:
 	 *   - 0
 	 *   - 1

--- a/class/command.php
+++ b/class/command.php
@@ -23,8 +23,23 @@ class WPSDBCLI extends WP_CLI_Command {
 	 */
 	public function migrate( $args, $assoc_args ) {
 		$profile = $args[0];
+		$manual_profile = [];
 
-		$result = wpsdb_migrate( $profile );
+		// Target manually (maybe no database available yet)
+		if ($assoc_args['connection-info'] && $assoc_args['action']) {
+			$manual_profile = array(
+				'connection_info' 		=> $assoc_args['connection-info'],
+				'action' 				=> $assoc_args['action'],
+				'create_backup' 		=> $assoc_args['create_backup'],
+				'backup_option' 		=> null,
+				'prefixed_tables' 		=> null,
+				'select_backup' 		=> null,
+				'table_migrate_option' 	=> null,
+				'select_tables' 		=> null,
+			);
+		}
+
+		$result = wpsdb_migrate( $profile, $manual_profile );
 
 		if ( true === $result ) {
 			WP_CLI::success( __( 'Migration successful.', 'wp-sync-db-cli' ) );

--- a/class/wpsdb-cli.php
+++ b/class/wpsdb-cli.php
@@ -21,7 +21,8 @@ class WPSDB_CLI extends WPSDB_Addon {
 		$this->set_time_limit();
 		$wpsdb->set_cli_migration();
 
-		$profile = apply_filters( 'wpsdb_cli_profile_before_migration', $manual_profile ?? $wpsdb_settings['profiles'][$profile] );
+		// If we have a profile by the supplied ID, then use it. Otherwise, attempt to use the provided manual_profile
+		$profile = apply_filters( 'wpsdb_cli_profile_before_migration', $wpsdb_settings['profiles'][$profile] ? $wpsdb_settings['profiles'][$profile] : $manual_profile );
 		$connection_info = explode( "\n", $profile['connection_info'] );
 		$form_data = http_build_query( $profile );
 

--- a/class/wpsdb-cli.php
+++ b/class/wpsdb-cli.php
@@ -10,18 +10,18 @@ class WPSDB_CLI extends WPSDB_Addon {
 		if( ! $this->meets_version_requirements( '1.4b1' ) ) return;
 	}
 
-	function cli_migration( $profile ) {
+	function cli_migration( $profile, $manual_profile ) {
 		global $wpsdb;
 		$wpsdb_settings = get_option( 'wpsdb_settings' );
 		--$profile;
 		if( ! $this->meets_version_requirements( '1.4b1' ) ) return $this->cli_error( __( 'Please update WP Sync DB.', 'wp-sync-db-cli' ) );
-		if( ! isset( $profile ) ) return $this->cli_error( __( 'Profile ID missing.', 'wp-sync-db-cli' ) );
-		if( ! isset( $wpsdb_settings['profiles'][$profile] ) ) return $this->cli_error( __( 'Profile ID not found.', 'wp-sync-db-cli' ) );
+		if( ! isset( $profile ) && ! isset( $manual_profile ) ) return $this->cli_error( __( 'Profile ID missing.', 'wp-sync-db-cli' ) );
+		if( ! isset( $manual_profile ) && ! isset( $wpsdb_settings['profiles'][$profile] ) ) return $this->cli_error( __( 'Profile ID not found.', 'wp-sync-db-cli' ) );
 
 		$this->set_time_limit();
 		$wpsdb->set_cli_migration();
 
-		$profile = apply_filters( 'wpsdb_cli_profile_before_migration', $wpsdb_settings['profiles'][$profile] );
+		$profile = apply_filters( 'wpsdb_cli_profile_before_migration', $manual_profile ?? $wpsdb_settings['profiles'][$profile] );
 		$connection_info = explode( "\n", $profile['connection_info'] );
 		$form_data = http_build_query( $profile );
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "wp-sync-db/wp-sync-db-cli",
+  "name": "josephdsouza86/wp-sync-db-cli",
   "type": "wordpress-plugin",
-  "homepage": "https://github.com/wp-sync-db/wp-sync-db-cli",
+  "homepage": "https://github.com/josephdsouza86/wp-sync-db-cli",
   "license": "GPL-2.0",
   "description": "WP Sync DB CLI Addon",
   "keywords": ["plugin","wordpress","wp-sync-db","cli"],

--- a/wp-sync-db-cli.php
+++ b/wp-sync-db-cli.php
@@ -29,10 +29,10 @@ function wp_sync_db_cli_loaded() {
 }
 add_action( 'plugins_loaded', 'wp_sync_db_cli_loaded', 20 );
 
-function wpsdb_migrate( $profile ) {
+function wpsdb_migrate( $profile, $manual_profile ) {
 	global $wpsdb_cli;
 	if( empty( $wpsdb_cli ) ) {
 		return new WP_Error( 'wpsdb_cli_error', __( 'WP Sync DB CLI class not available', 'wp-sync-db-cli' ) );
 	}
-	return $wpsdb_cli->cli_migration( $profile );
+	return $wpsdb_cli->cli_migration( $profile,  $manual_profile );
 }


### PR DESCRIPTION
The intention of my pull request is to allow a database to be migrated over without a profile having to already exist on the system. For example, it will be possible to create an empty WordPress installation and initiate a DB pull using a connection string only. Particularly, this is useful to more easily provision new environments (stage, UAT, etc) through WP CLI.

I've made the existing profile argument optional and added new arguments for connection-string, action and create-backup. The 3 new arguments can be provided to create a type of "manual profile" with mostly default settings. It's possible to also include the profile id, which will take precedence over the manual profile.

The most significant changes are to the `command.php` file, which means the main part of the functionality as originally found in `wpsdb-cli.php` pretty much works as it did before.

I've been using these changes on my systems to more quickly setup new websites where profiles don't exist yet and I think it will be a useful addition that others may benefit from too. So, I hope you like it.

